### PR TITLE
Update PlayerPuppetPS.cs

### DIFF
--- a/CyberCAT.Core/Classes/DumpedClasses/PlayerPuppetPS.cs
+++ b/CyberCAT.Core/Classes/DumpedClasses/PlayerPuppetPS.cs
@@ -16,5 +16,8 @@ namespace CyberCAT.Core.Classes.DumpedClasses
         
         [RealName("minigameBB")]
         public Handle<GameIBlackboard> MinigameBB { get; set; }
+		
+		[RealName("combatExitTimestamp")]        
+		public float CombatExitTimestamp { get; set; }
     }
 }


### PR DESCRIPTION
This fixes a parse error "PlayerPuppetPs.combatExitTimestamp" due patch 1.2. 